### PR TITLE
功能： 改善 東京之夜 主題的自定選項

### DIFF
--- a/lua/dast/plugins/colorscheme.lua
+++ b/lua/dast/plugins/colorscheme.lua
@@ -1,4 +1,3 @@
----@diagnostic disable: inject-field
 return {
   {
     "folke/tokyonight.nvim",
@@ -17,7 +16,6 @@ return {
       require("tokyonight").setup({
         style = "night",
         on_colors = function(colors)
-          ---@diagnostic disable-next-line: inject-field
           colors.bg = bg
           colors.bg_dark = bg_dark
           colors.bg_float = bg_dark


### PR DESCRIPTION
- 修改 `tokyonight.nvim` 的設置，新增選項 `on_colors`

Signed-off-by: Macbook <jackie@dast.tw>
