### PR TITLE
特性: 整合 `shfmt` 作為 Shell 腳本的格式化工具

### DIFF
--- a/lua/dast/plugins/formatting.lua
+++ b/lua/dast/plugins/formatting.lua
@@ -14,6 +14,7 @@ return {
         css = { "prettier" },
         html = { "prettier" },
         json = { "prettier" },
+        bash = { "shfmt" },
         yaml = { "prettier" },
         markdown = { "prettier" },
         graphql = { "prettier" },

--- a/lua/dast/plugins/lsp/lspconfig.lua
+++ b/lua/dast/plugins/lsp/lspconfig.lua
@@ -107,13 +107,20 @@ return {
       --     filetypes = { "graphql", "gql", "svelte", "typescriptreact", "javascriptreact" },
       --   })
       -- end,
-     -- ["emmet_ls"] = function()
+      -- ["emmet_ls"] = function()
       --   -- configure emmet language server
       --   lspconfig["emmet_ls"].setup({
       --     capabilities = capabilities,
       --     filetypes = { "html", "typescriptreact", "javascriptreact", "css", "sass", "scss", "less", "svelte" },
       --   })
       -- end,
+      ["shfmt"] = function()
+        -- configure emmet language server
+        lspconfig["shfmt"].setup({
+          capabilities = capabilities,
+          filetypes = { "sh", "bash", "mksh" },
+        })
+      end,
       ["lua_ls"] = function()
         -- configure lua server (with special settings)
         lspconfig["lua_ls"].setup({

--- a/lua/dast/plugins/lsp/mason.lua
+++ b/lua/dast/plugins/lsp/mason.lua
@@ -47,6 +47,7 @@ return {
         "pylint", -- Pylint is a static code analyser for Python 2 or 3.
         "stylua", -- An opinionated Lua code formatter.
         "isort", -- isort is a Python utility / library to sort imports alphabetically.
+        "shfmt", -- A shell formatter (sh/bash/mksh).
       },
     })
   end,


### PR DESCRIPTION
- 將 `shfmt` 新增為 `formatting.lua` 中支援的 `bash` 格式化工具
- 在 `lspconfig.lua` 中為 `sh`, `bash`, 和 `mksh` 加入 `shfmt` 設定在 `lspconfig`
- 將 `shfmt` 新增為 `mason.lua` 中 shell 腳本支援的格式化工具

Signed-off-by: Macbook <jackie@dast.tw>
