### PR TITLE
修订项目配置和忽略文件

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 lazy-lock.json
 .luarc.json
+

--- a/.stylua.toml
+++ b/.stylua.toml
@@ -1,2 +1,3 @@
 indent_type = "Spaces"
 indent_width = 2
+


### PR DESCRIPTION
- 将 `lazy-lock.json` 添加到 .gitignore
- 在 .stylua.toml 中将缩进类型调整为“空格”，并将缩进宽度设置为 2

Signed-off-by: Macbook <jackie@dast.tw>
