### PR TITLE
重構: 重新設計 Lua 檔案中的按鍵綁定和選項

### DIFF
--- a/lua/dast/core/keymaps.lua
+++ b/lua/dast/core/keymaps.lua
@@ -23,7 +23,7 @@ keymap.set("n", "<leader>-", "<C-x>", { desc = "Decrement number" }) -- decremen
 keymap.set("n", "<leader>sv", "<C-w>v", { desc = "Split window vertically" }) -- 右方開啟分割視窗
 keymap.set("n", "<leader>sh", "<C-w>s", { desc = "Split window horizontally" }) -- 下方開啟分割視窗
 keymap.set("n", "<leader>se", "<C-w>=", { desc = "Make splits equal size" }) -- 還原分割視窗布局回到初始尺寸
-keymap.set("n", "<leader>sx", "<cmd>close<CR>", { desc = "Close current split" }) -- 關閉分割是裝
+keymap.set("n", "<leader>sx", "<cmd>close<CR>", { desc = "Close current split" }) -- 關閉分割視窗
 
 keymap.set("n", "<leader>to", "<cmd>tabnew<CR>", { desc = "Open new tab" }) -- 開啟新分頁
 keymap.set("n", "<leader>tx", "<cmd>tabclose<CR>", { desc = "Close current tab" }) -- 關閉目前分頁

--- a/lua/dast/core/options.lua
+++ b/lua/dast/core/options.lua
@@ -1,46 +1,46 @@
 vim.cmd("let g:netrw_liststyle = 3")
 
-local opt = vim.opt -- for conciseness
+local opt = vim.opt -- 為了簡潔
 
--- line numbers
-opt.relativenumber = true -- show relative line numbers
-opt.number = true -- shows absolute line number on cursor line (when relative number is on)
+-- 行號
+opt.relativenumber = true -- 顯示相對行號
+opt.number = true -- 在光標行顯示絕對行號（啟用相對行號時）
 
--- tabs & indentation
-opt.tabstop = 2 -- 2 spaces for tabs (prettier default)
-opt.shiftwidth = 2 -- 2 spaces for indent width
-opt.expandtab = true -- expand tab to spaces
-opt.autoindent = true -- copy indent from current line when starting new one
+-- 標籤 & 縮進
+opt.tabstop = 2 -- 標籤為2個空格（prettier預設值）
+opt.shiftwidth = 2 -- 縮進寬度為2個空格
+opt.expandtab = true -- 將標籤轉換成空格
+opt.autoindent = true -- 新行開始時複製當前行的縮進
 
--- line wrapping
-opt.wrap = false -- disable line wrapping
+-- 換行
+opt.wrap = false -- 禁用自動換行
 
--- search settings
-opt.ignorecase = true -- ignore case when searching
-opt.smartcase = true -- if you include mixed case in your search, assumes you want case-sensitive
+-- 搜索設置
+opt.ignorecase = true -- 搜索時忽略大小寫
+opt.smartcase = true -- 如果搜索包含大小寫混合，則假設你需要區分大小寫
 
--- cursor line
-opt.cursorline = true -- highlight the current cursor line
+-- 光標行
+opt.cursorline = true -- 高亮當前光標所在行
 
--- appearance
+-- 外觀
 
--- turn on termguicolors for nightfly colorscheme to work
--- (have to use iterm2 or any other true color terminal)
+-- 啟用 termguicolors 以使 nightfly 色彩主題生效
+-- （必須使用 iterm2 或其他支持真彩色的終端機）
 opt.termguicolors = true
-opt.background = "dark" -- colorschemes that can be light or dark will be made dark
-opt.signcolumn = "yes" -- show sign column so that text doesn't shift
+opt.background = "dark" -- 可以是亮色或暗色的色彩主題將被設為暗色
+opt.signcolumn = "yes" -- 顯示標誌欄，以防文本位移
 
--- backspace
-opt.backspace = "indent,eol,start" -- allow backspace on indent, end of line or insert mode start position
+-- 回退鍵
+opt.backspace = "indent,eol,start" -- 允許在縮進、行尾或插入模式起始位置使用回退鍵
 
--- clipboard
-opt.clipboard:append("unnamedplus") -- use system clipboard as default register
+-- 剪貼板
+opt.clipboard:append("unnamedplus") -- 使用系統剪貼板作為預設寄存器
 
--- split windows
-opt.splitright = true -- split vertical window to the right
-opt.splitbelow = true -- split horizontal window to the bottom
+-- 分割窗口
+opt.splitright = true -- 垂直分割窗口向右分割
+opt.splitbelow = true -- 水平分割窗口向下分割
 
--- turn off swapfile
+-- 關閉交換檔案
 opt.swapfile = false
 
 vim.g.python3_host_prog = "~/.pyenv/shims/python3"


### PR DESCRIPTION
- 更新在 `keymaps.lua` 中關閉分割視窗的按鍵綁定
- 重構在 `options.lua` 中設置 Vim 選項的程式碼

Signed-off-by: HomePC-WSL <jackie@dast.tw>
