### PR TITLE
功能: 更新插件配置以增強功能

### DIFF
--- a/lua/dast/plugins/autopairs.lua
+++ b/lua/dast/plugins/autopairs.lua
@@ -16,7 +16,6 @@ return {
         javascript = { "template_string" }, -- don't add pairs in javscript template_string treesitter nodes
         java = false, -- don't check treesitter on java
         sh = false, -- enable autopairs in all shell script treesitter nodes
-        python = false, -- enable autopairs in all python treesitter nodes
       },
     })
 

--- a/lua/dast/plugins/nvim-cmp.lua
+++ b/lua/dast/plugins/nvim-cmp.lua
@@ -46,10 +46,10 @@ return {
       -- sources for autocompletion
       sources = cmp.config.sources({
         { name = "nvim_lsp" },
-        { name = "bashls" },
         { name = "luasnip" }, -- snippets
         { name = "buffer" }, -- text within current buffer
         { name = "path" }, -- file system paths
+        { name = "bashls" },
       }),
 
       -- configure lspkind for vs-code like pictograms in completion menu


### PR DESCRIPTION
- 在插件配置中為 Python 禁用自動匹配
- 將 `bashls` 添加為 `nvim-cmp` 插件的自動完成源

Signed-off-by: Macbook <jackie@dast.tw>
