### PR TITLE
功能: 重新設計插件系統以整合 ChatGPT

### DIFF
--- a/lua/dast/plugins/chatgpt.lua
+++ b/lua/dast/plugins/chatgpt.lua
@@ -1,0 +1,14 @@
+return {
+  "jackMort/CHatGPT.nvim",
+  event = "VeryLazy",
+  dependencies = {
+    "MunifTanjim/nui.nvim",
+    "nvim-lua/plenary.nvim",
+    "nvim-telescope/telescope.nvim",
+  },
+  config = function()
+    require("chatgpt").setup({
+      async_api_key_cmd = "echo $OPENAI_API_KEY",
+    })
+  end,
+}


### PR DESCRIPTION
- 在 `dast/plugins` 目錄中新增一個名為 `chatgpt.lua` 的 Lua 檔案
- 定義一個包含依賴和設置函數的 ChatGPT 插件配置表

Signed-off-by: Macbook <jackie@dast.tw>
