### PR TITLE
GIT 提交訊息：

### DIFF
--- a/lua/dast/plugins/formatting.lua
+++ b/lua/dast/plugins/formatting.lua
@@ -6,17 +6,8 @@ return {
 
     conform.setup({
       formatters_by_ft = {
-        javascript = { "prettier" },
-        typescript = { "prettier" },
-        javascriptreact = { "prettier" },
-        typescriptreact = { "prettier" },
-        svelte = { "prettier" },
-        css = { "prettier" },
-        html = { "prettier" },
         markdown = { "prettier" },
-        graphql = { "prettier" },
         json = { "prettier" },
-        liquid = { "prettier" },
         bash = { "shellcheck" },
         sh = { "shellcheck" },
         yaml = { "prettier" },

--- a/lua/dast/plugins/lsp/lspconfig.lua
+++ b/lua/dast/plugins/lsp/lspconfig.lua
@@ -99,20 +99,6 @@ return {
           end,
         })
       end,
-      ["graphql"] = function()
-        -- configure graphql language server
-        lspconfig["graphql"].setup({
-          capabilities = capabilities,
-          filetypes = { "graphql", "gql", "svelte", "typescriptreact", "javascriptreact" },
-        })
-      end,
-      ["emmet_ls"] = function()
-        -- configure emmet language server
-        lspconfig["emmet_ls"].setup({
-          capabilities = capabilities,
-          filetypes = { "html", "typescriptreact", "javascriptreact", "css", "sass", "scss", "less", "svelte" },
-        })
-      end,
       ["bashls"] = function()
         -- configure lua server (with special settings)
         lspconfig["bashls"].setup({

--- a/lua/dast/plugins/lsp/mason.lua
+++ b/lua/dast/plugins/lsp/mason.lua
@@ -27,14 +27,6 @@ return {
     mason_lspconfig.setup({
       -- list of servers for mason to install
       ensure_installed = {
-        "tsserver",
-        "html",
-        "cssls",
-        "tailwindcss",
-        "svelte",
-        "graphql",
-        "emmet_ls",
-        "prismals",
         "bashls",
         "lua_ls",
         "pyright",
@@ -49,7 +41,6 @@ return {
         "pylint", -- Pylint is a static code analyser for Python 2 or 3.
         "stylua", -- An opinionated Lua code formatter.
         "isort", -- isort is a Python utility / library to sort imports alphabetically.
-        "eslint_d", -- js linte
         "shfmt", -- A shell formatter (sh/bash/mksh).
       },
     })

--- a/lua/dast/plugins/nvim-cmp.lua
+++ b/lua/dast/plugins/nvim-cmp.lua
@@ -49,7 +49,7 @@ return {
         { name = "luasnip" }, -- snippets
         { name = "buffer" }, -- text within current buffer
         { name = "path" }, -- file system paths
-        { name = "bashls" },
+        { name = "bash_lsp" },
       }),
 
       -- configure lspkind for vs-code like pictograms in completion menu

--- a/lua/dast/plugins/substitute.lua
+++ b/lua/dast/plugins/substitute.lua
@@ -9,9 +9,9 @@ return {
     -- set keymaps
     local keymap = vim.keymap -- for conciseness
 
-    vim.keymap.set("n", "s", substitute.operator, { desc = "Substitute with motion" })
-    vim.keymap.set("n", "ss", substitute.line, { desc = "Substitute line" })
-    vim.keymap.set("n", "S", substitute.eol, { desc = "Substitute to end of line" })
-    vim.keymap.set("x", "s", substitute.visual, { desc = "Substitute in visual mode" })
+    keymap.set("n", "s", substitute.operator, { desc = "Substitute with motion" })
+    keymap.set("n", "ss", substitute.line, { desc = "Substitute line" })
+    keymap.set("n", "S", substitute.eol, { desc = "Substitute to end of line" })
+    keymap.set("x", "s", substitute.visual, { desc = "Substitute in visual mode" })
   end,
 }


### PR DESCRIPTION
重構：重構語言伺服器配置和完成插件

- 從 `formatting.lua` 中刪除各種語言的格式配置
- 從 `lspconfig.lua` 中移除 `graphql` 和 `emmet` 的語言伺服器配置
- 減少 `mason.lua` 中已安裝伺服器的列表
- 在 `nvim-cmp.lua` 中更新完成插件，使用 `bash_lsp` 取代 `bashls`
- 在 `substitute.lua` 中重構替換的鍵盤映射設置

Signed-off-by: HomePC-WSL <jackie@dast.tw>
