### PR TITLE
提要: 在插件處理中重構語言伺服器配置

### DIFF
--- a/lua/dast/plugins/nvim-cmp.lua
+++ b/lua/dast/plugins/nvim-cmp.lua
@@ -50,7 +50,6 @@ return {
         { name = "luasnip" }, -- snippets
         { name = "buffer" }, -- text within current buffer
         { name = "path" }, -- file system paths
-        { name = "bash_lsp" },
       }),
 
       -- configure lspkind for vs-code like pictograms in completion menu

--- a/lua/dast/plugins/trouble.lua
+++ b/lua/dast/plugins/trouble.lua
@@ -1,0 +1,12 @@
+return {
+  "folke/trouble.nvim",
+  dependencies = { "nvim-tree/nvim-web-devicons", "folke/todo-comments.nvim" },
+  keys = {
+    { "<leader>xx", "<cmd>TroubleToggle<CR>", desc = "Open/close trouble list" },
+    { "<leader>xw", "<cmd>TroubleToggle workspace_diagnostics<CR>", desc = "Open trouble workspace diagnostics" },
+    { "<leader>xd", "<cmd>TroubleToggle document_diagnostics<CR>", desc = "Open trouble document diagnostics" },
+    { "<leader>xq", "<cmd>TroubleToggle quickfix<CR>", desc = "Open trouble quickfix list" },
+    { "<leader>xl", "<cmd>TroubleToggle loclist<CR>", desc = "Open trouble location list" },
+    { "<leader>xt", "<cmd>TodoTrouble<CR>", desc = "Open todos in trouble" },
+  },
+}


### PR DESCRIPTION
- 從 nvim-cmp.lua 中的可用語言伺服器中移除 `bash_lsp`
- 新增一個用於處理插件問題的新檔案

Signed-off-by: Macbook <jackie@dast.tw>
