### PR TITLE
修正：更新程式碼檢查工具和語言伺服器插件的設定

### DIFF
--- a/lua/dast/plugins/formatting.lua
+++ b/lua/dast/plugins/formatting.lua
@@ -13,7 +13,7 @@ return {
         yaml = { "prettier" },
         lua = { "stylua" },
         python = { "isort", "black" },
-        zsh = { "bueatysh" },
+        zsh = { "beautysh" },
       },
       format_on_save = {
         lsp_fallback = true,

--- a/lua/dast/plugins/linting.lua
+++ b/lua/dast/plugins/linting.lua
@@ -8,6 +8,7 @@ return {
       python = { "pylint" },
       bash = { "shellcheck" },
       sh = { "shellcheck" },
+      zsh = { "beautysh" },
     }
 
     local lint_augroup = vim.api.nvim_create_augroup("lint", { clear = true })

--- a/lua/dast/plugins/lsp/lspconfig.lua
+++ b/lua/dast/plugins/lsp/lspconfig.lua
@@ -129,7 +129,7 @@ return {
         -- configure powershell language server
         lspconfig["powershell_es"].setup({
           capabilities = capabilities,
-          filetypes = { "powershell" },
+          filetypes = { "ps1" },
         })
       end,
     })


### PR DESCRIPTION
- 修正 zsh 插件名稱中的拼字錯誤，從 &#34;bueatysh&#34; 修改為 &#34;beautysh&#34;
- 將 &#34;beautysh&#34; 添加為 zsh 的程式碼檢查工具
- 修改 lspconfig 插件中針對 PowerShell 的檔案類型分配

Signed-off-by: OfficePC-WSL <jackie@dast.tw>
