### PR TITLE
修正：重新配置插件相依性以增進相容性

### DIFF
--- a/lua/dast/plugins/autopairs.lua
+++ b/lua/dast/plugins/autopairs.lua
@@ -16,7 +16,6 @@ return {
         javascript = { "template_string" }, -- don't add pairs in javscript template_string treesitter nodes
         java = false, -- don't check treesitter on java
         sh = false, -- enable autopairs in all shell script treesitter nodes
-        zsh = false,
         ps1 = false,
       },
     })

--- a/lua/dast/plugins/formatting.lua
+++ b/lua/dast/plugins/formatting.lua
@@ -13,7 +13,6 @@ return {
         yaml = { "prettier" },
         lua = { "stylua" },
         python = { "isort", "black" },
-        zsh = { "beautysh" },
       },
       format_on_save = {
         lsp_fallback = true,

--- a/lua/dast/plugins/linting.lua
+++ b/lua/dast/plugins/linting.lua
@@ -8,7 +8,6 @@ return {
       python = { "pylint" },
       bash = { "shellcheck" },
       sh = { "shellcheck" },
-      zsh = { "beautysh" },
     }
 
     local lint_augroup = vim.api.nvim_create_augroup("lint", { clear = true })

--- a/lua/dast/plugins/lsp/mason.lua
+++ b/lua/dast/plugins/lsp/mason.lua
@@ -43,7 +43,6 @@ return {
         "stylua", -- An opinionated Lua code formatter.
         "isort", -- isort is a Python utility / library to sort imports alphabetically.
         "shfmt", -- A shell formatter (sh/bash/mksh).
-        "beautysh",
       },
     })
   end,


### PR DESCRIPTION
- 從自動成對和檢查插件中刪除 `zsh`
- 從格式化檢查插件中刪除 `zsh`
- 從檢查和格式化插件中刪除 `beautysh`

Signed-off-by: Macbook <jackie@dast.tw>
