### PR TITLE
功能：整合新插件功能並更新 API 金鑰命令

### DIFF
--- a/lua/dast/plugins/chatgpt.lua
+++ b/lua/dast/plugins/chatgpt.lua
@@ -1,5 +1,6 @@
 return {
   "jackMort/ChatGPT.nvim",
+  enabled = false,
   event = "VeryLazy",
   dependencies = {
     "MunifTanjim/nui.nvim",
@@ -9,7 +10,7 @@ return {
   },
   config = function()
     require("chatgpt").setup({
-      api_key_cmd = "gpg --decrypt ~/openai_api_key.gpg",
+      api_key_cmd = "gpg --decrypt ~/secret.txt.gpg",
     })
 
     vim.keymap.set("n", "<leader>cc", "<cmd>ChatGPT<CR>", { desc = "ChatGPT" })


### PR DESCRIPTION
- 啟用 `ChatGPT` 插件
- 更新 API 金鑰命令以使用不同檔案

Signed-off-by: Macbook <jackie@dast.tw>
