### PR TITLE
GIT 提交訊息：

### DIFF
--- a/lua/dast/plugins/formatting.lua
+++ b/lua/dast/plugins/formatting.lua
@@ -8,7 +8,7 @@ return {
       formatters_by_ft = {
         markdown = { "prettier" },
         json = { "prettier" },
-        bash = { "shellcheck" },
+        bash = { "shfmt" },
         sh = { "shfmt" },
         yaml = { "prettier" },
         lua = { "stylua" },

--- a/lua/dast/plugins/lsp/lspconfig.lua
+++ b/lua/dast/plugins/lsp/lspconfig.lua
@@ -1,3 +1,4 @@
+---@diagnostic disable: undefined-global
 return {
   "neovim/nvim-lspconfig",
   event = { "BufReadPre", "BufNewFile" },
@@ -88,6 +89,7 @@ return {
         -- configure lua server (with special settings)
         lspconfig["lua_ls"].setup({
           capabilities = capabilities,
+          on_attach = on_attach,
           settings = {
             lua = {
               -- make the language server recognize "vim" global
@@ -114,14 +116,6 @@ return {
         lspconfig["pyright"].setup({
           capabilities = capabilities,
           filetypes = { "python" },
-          on_attach = on_attach,
-        })
-      end,
-      ["powershell_es"] = function()
-        -- configure powershell language server
-        lspconfig["powershell_es"].setup({
-          capabilities = capabilities,
-          filetypes = { "ps1" },
           on_attach = on_attach,
         })
       end,

--- a/lua/dast/plugins/lsp/mason.lua
+++ b/lua/dast/plugins/lsp/mason.lua
@@ -30,7 +30,6 @@ return {
         "bashls",
         "lua_ls",
         "pyright",
-        "powershell_es",
       },
     })
 


### PR DESCRIPTION
重構：重構編碼風格和配置設置

- 將 `bash` 檔案的格式化工具從 `shellcheck` 更改為 `shfmt`
- 添加一個註釋以禁用未定義的全域診斷信息
- 為 `lua_ls` 語言伺服器配置添加一個 `on_attach` 函數

Signed-off-by: HomePC-WSL <jackie@dast.tw>
