### PR TITLE
功能: 重構 ChatGPT 函數的按鍵映射初始化

### DIFF
--- a/lua/dast/plugins/chatgpt.lua
+++ b/lua/dast/plugins/chatgpt.lua
@@ -1,7 +1,7 @@
 return {
   "jackMort/ChatGPT.nvim",
   -- enabled = false,
-  evnet = { "InsertEnter" },
+  evnet = { "BufReadPre", "BufNewFile" },
   dependencies = {
     "MunifTanjim/nui.nvim",
     "nvim-lua/plenary.nvim",
@@ -10,13 +10,15 @@ return {
   },
   config = function()
     local home = vim.fn.expand("$HOME")
-    local keymap = vim.keymap
-
     require("chatgpt").setup({
       api_key_cmd = "gpg --decrypt " .. home .. "/openai.gpg",
     })
-    keymap.set("n", "<Leader>cc", "<cmd>ChatGPT<CR>", { desc = "Open ChatGPT" })
-    keymap.set("n", "<Leader>cm", "<cmd>CHatGPTCompleteCode<CR>", { desc = "ChatGPT AutoComplete Code" })
-    keymap.set("n", "<Leader>ct", "<cmd>ChatGPTRun add_tests<CR>", { desc = "ChatGPT Add Test Code" })
+    vim.keymap.set("n", "<Leader>cm", "<cmd>CHatGPTCompleteCode<CR>", { desc = "ChatGPT AutoComplete Code" })
+    vim.keymap.set("n", "<Leader>ct", "<cmd>ChatGPTRun add_tests<CR>", { desc = "ChatGPT Add Test Code" })
   end,
+  key = {
+    "<Leader>cc",
+    "<cmd>ChatGPT<CR>",
+    { desc = "Open ChatGPT" },
+  },
 }


### PR DESCRIPTION
- 將事件觸發器從 &#34;InsertEnter&#34; 更新為 &#34;BufReadPre&#34; 和 &#34;BufNewFile&#34;
- 刪除未使用的按鍵映射初始化程式碼
- 使用 &#34;vim.keymap.set&#34; 取代 &#34;keymap.set&#34; 進行按鍵映射初始化的更新
- 為 ChatGPT 函數增加按鍵映射

Signed-off-by: HomePC-WSL <jackie@dast.tw>
