### PR TITLE
特性: 配置`ChatGPT`插件

### DIFF
--- a/lua/dast/plugins/chatgpt.lua
+++ b/lua/dast/plugins/chatgpt.lua
@@ -1,6 +1,6 @@
 return {
   "jackMort/ChatGPT.nvim",
-  -- enabled = false,
+  enabled = false,
   evnet = "VeryLazy",
   dependencies = {
     "MunifTanjim/nui.nvim",


### PR DESCRIPTION
- 通過將`enabled`設置為`false`啟用`ChatGPT`插件。

Signed-off-by: Macbook <jackie@dast.tw>
