### PR TITLE
提交: 停用 "gbprod/substitute.nvim" 擴充功能

### DIFF
--- a/lua/dast/plugins/substitute.lua
+++ b/lua/dast/plugins/substitute.lua
@@ -1,5 +1,6 @@
 return {
   "gbprod/substitute.nvim",
+  enabled = false,
   event = { "BufReadPre", "BufNewFile" },
   config = function()
     local substitute = require("substitute")


### PR DESCRIPTION
- 停用 "gbprod/substitute.nvim" 擴充功能
- 在擴充功能設定中新增 `enabled` 標記，設為 `false` 以供 "gbprod/substitute.nvim"。

Signed-off-by: OfficePC-WSL <jackie@dast.tw>
