### PR TITLE
修復：重構代碼補全命令

### DIFF
--- a/lua/dast/plugins/chatgpt.lua
+++ b/lua/dast/plugins/chatgpt.lua
@@ -16,7 +16,7 @@ return {
   end,
   keys = {
     { "<Leader>cc", "<cmd>ChatGPT<CR>", desc = "Open ChatGPT" },
-    { "<Leader>cm", "<cmd>CHatGPTCompleteCode<CR>", desc = "ChatGPT AutoComplete Code" },
+    { "<Leader>cm", "<cmd>ChatGPTCompleteCode<CR>", desc = "ChatGPT AutoComplete Code" },
     { "<Leader>ca", "<cmd>ChatGPTRun add_tests<CR>", desc = "ChatGPT Add Test Code" },
   },
 }


### PR DESCRIPTION
- 修正 ChatGPT 代碼補全命令中的拼寫錯誤

Signed-off-by: OfficePC-WSL <jackie@dast.tw>
