### PR TITLE
GIT 提交訊息：

### DIFF
--- a/lua/dast/plugins/chatgpt.lua
+++ b/lua/dast/plugins/chatgpt.lua
@@ -17,6 +17,6 @@ return {
   keys = {
     { "<Leader>cc", "<cmd>ChatGPT<CR>", desc = "Open ChatGPT" },
     { "<Leader>cm", "<cmd>ChatGPTCompleteCode<CR>", desc = "ChatGPT AutoComplete Code" },
-    { "<Leader>ca", "<cmd>ChatGPTRun add_tests<CR>", desc = "ChatGPT Add Test Code" },
+    { "<Leader>ct", "<cmd>ChatGPTRun add_tests<CR>", desc = "ChatGPT Add Test Code" },
   },
 }


### PR DESCRIPTION
重構：調整 ChatGPT 執行命令的按鍵映射

- 修改 ChatGPT 執行 add_tests 的按鍵映射為 "&#34;&lt;Leader&gt;ct&#34;"
- 刪除 ChatGPT 執行 add_tests 的按鍵映射 "&#34;&lt;Leader&gt;ca&#34;"

Signed-off-by: OfficePC-WSL <jackie@dast.tw>
