### PR TITLE
功能：禁用 bufferline 插件並清理相關代碼

### DIFF
--- a/lua/dast/plugins/bufferline.lua
+++ b/lua/dast/plugins/bufferline.lua
@@ -1,5 +1,6 @@
 return {
   "akinsho/bufferline.nvim",
+  enabled = false,
   dependencies = { "nvim-tree/nvim-web-devicons" },
   version = "*",
   opts = {


### PR DESCRIPTION
- 通過設置 `enabled = false` 來禁用 bufferline 插件

Signed-off-by: HomePC-WSL <jackie@dast.tw>
