### PR TITLE
修正：預設停用 Lua 檔案中所有插件功能

### DIFF
--- a/lua/dast/plugins/chatgpt.lua
+++ b/lua/dast/plugins/chatgpt.lua
@@ -1,6 +1,6 @@
 return {
   "jackMort/ChatGPT.nvim",
-  -- cond = false,
+  cond = false,
   config = function()
     local home = vim.fn.expand("$HOME")
 

--- a/lua/dast/plugins/colorscheme.lua
+++ b/lua/dast/plugins/colorscheme.lua
@@ -2,7 +2,7 @@
 return {
   {
     "folke/tokyonight.nvim",
-    -- enabled = false,
+    -- cond = false,
     priority = 1000, -- make sure to load this before all the other start plugins
     config = function()
       local bg = "#011628"

--- a/lua/dast/plugins/comment.lua
+++ b/lua/dast/plugins/comment.lua
@@ -1,7 +1,7 @@
 ---@diagnostic disable: missing-fields
 return {
   "numToStr/Comment.nvim",
-  -- enabled = false,
+  -- cond = false,
   event = { "BufReadPre", "BufNewFile" },
   dependencies = {
     "JoosepAlviste/nvim-ts-context-commentstring",

--- a/lua/dast/plugins/dressing.lua
+++ b/lua/dast/plugins/dressing.lua
@@ -1,5 +1,5 @@
 return {
   "stevearc/dressing.nvim",
-  -- enabled = false,
+  -- cond = false,
   event = "VeryLazy",
 }

--- a/lua/dast/plugins/formatting.lua
+++ b/lua/dast/plugins/formatting.lua
@@ -1,6 +1,6 @@
 return {
   "stevearc/conform.nvim",
-  -- enabled = false,
+  -- cond = false,
   event = { "BufReadPre", "BufNewFile" },
   config = function()
     local conform = require("conform")

--- a/lua/dast/plugins/gitsigns.lua
+++ b/lua/dast/plugins/gitsigns.lua
@@ -1,6 +1,6 @@
 return {
   "lewis6991/gitsigns.nvim",
-  -- enabled = false,
+  -- cond = false,
   event = { "BufReadPre", "BufNewFile" },
   opts = {
     on_attach = function(bufnr)

--- a/lua/dast/plugins/indent-blankline.lua
+++ b/lua/dast/plugins/indent-blankline.lua
@@ -1,6 +1,6 @@
 return {
   "lukas-reineke/indent-blankline.nvim",
-  -- enabled = false,
+  -- cond = false,
   event = { "BufReadPre", "BufNewFile" },
   main = "ibl",
   opts = {

--- a/lua/dast/plugins/init.lua
+++ b/lua/dast/plugins/init.lua
@@ -1,5 +1,5 @@
 return {
   "nvim-lua/plenary.nvim", -- lua functions that many plugins use
-  -- enabled = false,
+  -- cond = false,
   "christoomey/vim-tmux-navigator", -- tmux & split window navigation
 }

--- a/lua/dast/plugins/lazygit.lua
+++ b/lua/dast/plugins/lazygit.lua
@@ -1,6 +1,6 @@
 return {
   "kdheepak/lazygit.nvim",
-  -- enabled = false,
+  -- cond = false,
   cmd = {
     "LazyGit",
     "LazyGitConfig",

--- a/lua/dast/plugins/linting.lua
+++ b/lua/dast/plugins/linting.lua
@@ -1,6 +1,6 @@
 return {
   "mfussenegger/nvim-lint",
-  -- enabled = false,
+  -- cond = false,
   event = { "BufReadPre", "BufNewFile" },
   config = function()
     local lint = require("lint")

--- a/lua/dast/plugins/lualine.lua
+++ b/lua/dast/plugins/lualine.lua
@@ -1,6 +1,6 @@
 return {
   "nvim-lualine/lualine.nvim",
-  -- enabled = false,
+  -- cond = false,
   dependencies = { "nvim-tree/nvim-web-devicons" },
   config = function()
     local lualine = require("lualine")

--- a/lua/dast/plugins/noice.lua
+++ b/lua/dast/plugins/noice.lua
@@ -1,6 +1,6 @@
 return {
   "folke/noice.nvim",
-  -- enabled = false,
+  -- cond = false,
   event = "VeryLazy",
   opts = {
     -- add any options here

--- a/lua/dast/plugins/nvim-cmp.lua
+++ b/lua/dast/plugins/nvim-cmp.lua
@@ -1,7 +1,7 @@
 ---@diagnostic disable: missing-fields
 return {
   "hrsh7th/nvim-cmp",
-  -- enabled = false,
+  -- cond = false,
   event = "InsertEnter",
   dependencies = {
     "hrsh7th/cmp-buffer", -- source for text in buffer

--- a/lua/dast/plugins/nvim-tree.lua
+++ b/lua/dast/plugins/nvim-tree.lua
@@ -1,6 +1,6 @@
 return {
   "nvim-tree/nvim-tree.lua",
-  -- enabled = false,
+  -- cond = false,
   dependencies = "nvim-tree/nvim-web-devicons",
   config = function()
     local nvimtree = require("nvim-tree")

--- a/lua/dast/plugins/substitute.lua
+++ b/lua/dast/plugins/substitute.lua
@@ -1,6 +1,5 @@
 return {
   "gbprod/substitute.nvim",
-  -- enabled = false,
   -- cond = false,
   event = { "BufReadPre", "BufNewFile" },
   config = function()

--- a/lua/dast/plugins/surround.lua
+++ b/lua/dast/plugins/surround.lua
@@ -1,6 +1,6 @@
 return {
   "kylechui/nvim-surround",
-  -- enabled = false,
+  -- cond = false,
   event = { "BufReadPre", "BufNewFile" },
   version = "*", -- Use for stability; omit to use `main` branch for the latest features
   config = true,

--- a/lua/dast/plugins/telescope.lua
+++ b/lua/dast/plugins/telescope.lua
@@ -1,6 +1,6 @@
 return {
   "nvim-telescope/telescope.nvim",
-  -- enabled = false,
+  -- cond = false,
   branch = "0.1.x",
   dependencies = {
     "nvim-lua/plenary.nvim",

--- a/lua/dast/plugins/todo-comments.lua
+++ b/lua/dast/plugins/todo-comments.lua
@@ -1,6 +1,6 @@
 return {
   "folke/todo-comments.nvim",
-  -- enabled = false,
+  -- cond = false,
   event = { "BufReadPre", "BufNewFile" },
   dependencies = { "nvim-lua/plenary.nvim" },
   config = function()

--- a/lua/dast/plugins/treesitter.lua
+++ b/lua/dast/plugins/treesitter.lua
@@ -1,7 +1,7 @@
 ---@diagnostic disable: missing-fields, assign-type-mismatch
 return {
   "nvim-treesitter/nvim-treesitter",
-  -- enabled = false,
+  -- cond = false,
   event = { "BufReadPre", "BufNewFile" },
   build = ":TSUpdate",
   dependencies = {

--- a/lua/dast/plugins/trouble.lua
+++ b/lua/dast/plugins/trouble.lua
@@ -1,6 +1,6 @@
 return {
   "folke/trouble.nvim",
-  -- enabled = false,
+  -- cond = false,
   dependencies = { "nvim-tree/nvim-web-devicons", "folke/todo-comments.nvim" },
   keys = {
     { "<leader>xx", "<cmd>TroubleToggle<CR>", desc = "Open/close trouble list" },

--- a/lua/dast/plugins/vim-maximizer.lua
+++ b/lua/dast/plugins/vim-maximizer.lua
@@ -1,6 +1,6 @@
 return {
   "szw/vim-maximizer",
-  -- enabled = false,
+  -- cond = false,
   event = { "BufReadPre", "BufNewFile" },
   keys = {
     { "<leader>sm", "<cmd>MaximizerToggle<CR>", desc = "Maximize/minimize a split" },

--- a/lua/dast/plugins/which-key.lua
+++ b/lua/dast/plugins/which-key.lua
@@ -1,6 +1,6 @@
 return {
   "folke/which-key.nvim",
-  -- enabled = false,
+  cond = false,
   event = "VeryLazy",
   init = function()
     vim.o.timeout = true


### PR DESCRIPTION
- 在 `lua/dast/plugins/chatgpt.lua` 檔案中，將 `cond` 值更新為 `false`
- 在 `lua/dast/plugins/colorscheme.lua` 檔案中，將 `enabled` 值更新為 `false` 值為 `cond`
- 在 `lua/dast/plugins/comment.lua` 檔案中，將 `enabled` 值更新為 `false` 值為 `cond`
- 在 `lua/dast/plugins/dressing.lua` 檔案中，將 `enabled` 值更新為 `false` 值為 `cond`
- 在 `lua/dast/plugins/formatting.lua` 檔案中，將 `enabled` 值更新為 `false` 值為 `cond`
- 在 `lua/dast/plugins/gitsigns.lua` 檔案中，將 `enabled` 值更新為 `false` 值為 `cond`
- 在 `lua/dast/plugins/indent-blankline.lua` 檔案中，將 `enabled` 值更新為 `false` 值

Signed-off-by: HomePC-WSL <jackie@dast.tw>
