### PR TITLE
文件: 改進鍵盤映射配置中的一致性

### DIFF
--- a/lua/dast/plugins/which-key.lua
+++ b/lua/dast/plugins/which-key.lua
@@ -2,6 +2,7 @@ return {
   "folke/which-key.nvim",
   -- cond = false,
   event = "VeryLazy",
+  --BUG: conflicting keymaps "gc"
   init = function()
     vim.o.timeout = true
     vim.o.timeoutlen = 500


### PR DESCRIPTION
- 新增一個關於 `which-key` 外掛程式中衝突鍵盤映射的註釋。

Signed-off-by: HomePC-WSL <jackie@dast.tw>
