### PR TITLE
GIT 提交訊息： 重構：更新檔案註解以提高清晰度

### DIFF
--- a/lua/dast/plugins/which-key.lua
+++ b/lua/dast/plugins/which-key.lua
@@ -2,7 +2,7 @@ return {
   "folke/which-key.nvim",
   -- cond = false,
   event = "VeryLazy",
-  --BUG: conflicting keymaps "gc"
+  --TODO: check conflicting keymaps "gc"
   init = function()
     vim.o.timeout = true
     vim.o.timeoutlen = 500


### PR DESCRIPTION
- 將有關 `which-key.lua` 外掛程式中衝突按鍵映射的註解從 `--BUG` 更改為 `--TODO`。

Signed-off-by: HomePC-WSL <jackie@dast.tw>
