### PR TITLE
重新設計: 重構按鍵映射和超時設定

### DIFF
--- a/lua/dast/plugins/which-key.lua
+++ b/lua/dast/plugins/which-key.lua
@@ -1,8 +1,8 @@
 return {
   "folke/which-key.nvim",
-  -- cond = false,
+  cond = false,
   event = "VeryLazy",
-  --TODO: check conflicting keymaps "gc"
+  --BUG: conflicting keymaps "gc"
   init = function()
     vim.o.timeout = true
     vim.o.timeoutlen = 500


### PR DESCRIPTION
- 將 `cond` 的值更改為 `false`
- 在程式碼中新增有關衝突按鍵映射的註釋
- 調整 `timeoutlen` 的值為 `500`

Signed-off-by: Macbook <jackie@dast.tw>
