### PR TITLE
修復：更新按鍵映射處理和超時設置

### DIFF
--- a/lua/dast/plugins/which-key.lua
+++ b/lua/dast/plugins/which-key.lua
@@ -6,6 +6,8 @@ return {
   init = function()
     vim.o.timeout = true
     vim.o.timeoutlen = 300
+    -- unmap gc keymap
+    vim.api.nvim_set_keymap("n", "gc", "", { noremap = true, silent = true })
   end,
   opts = {
     -- your configuration comes here


### PR DESCRIPTION
- 添加解除 `gc` 按鍵映射的邏輯
- 將 `timeoutlen` 增加至 `300`

Signed-off-by: OfficePC-WSL <jackie@dast.tw>
