### PR TITLE
refactor: refactor keymaps, options, and plugins

### DIFF
--- a/lua/dast/core/keymaps.lua
+++ b/lua/dast/core/keymaps.lua
@@ -3,17 +3,11 @@ vim.g.mapleader = " "
 
 local keymap = vim.keymap -- for conciseness
 
----------------------
--- General Keymaps -------------------
-
 -- use jk to exit insert mode
 keymap.set("i", "jk", "<ESC>", { desc = "Exit insert mode with jk" })
 
 -- clear search highlights
 keymap.set("n", "<leader>nh", ":nohl<CR>", { desc = "Clear search highlights" })
-
--- delete single character without copying into register
--- keymap.set("n", "x", '"_x')
 
 -- increment/decrement numbers
 keymap.set("n", "<leader>+", "<C-a>", { desc = "Increment number" }) -- increment

--- a/lua/dast/core/options.lua
+++ b/lua/dast/core/options.lua
@@ -1,13 +1,13 @@
-vim.cmd("let g:netrw_liststyle = 3")
+vim.cmd("let g:netrw_liststyle = 3") -- 設定 netrw 的列表樣式為樹狀圖
 
-local opt = vim.opt -- 為了簡潔
+local opt = vim.opt -- 為了簡潔，使用 opt 來代替 vim.opt
 
 -- 行號
 opt.relativenumber = true -- 顯示相對行號
 opt.number = true -- 在光標行顯示絕對行號（啟用相對行號時）
 
 -- 標籤 & 縮進
-opt.tabstop = 2 -- 標籤為2個空格（prettier預設值）
+opt.tabstop = 2 -- 標籤為2個空格（prettier 預設值）
 opt.shiftwidth = 2 -- 縮進寬度為2個空格
 opt.expandtab = true -- 將標籤轉換成空格
 opt.autoindent = true -- 新行開始時複製當前行的縮進
@@ -17,17 +17,15 @@ opt.wrap = false -- 禁用自動換行
 
 -- 搜索設置
 opt.ignorecase = true -- 搜索時忽略大小寫
-opt.smartcase = true -- 如果搜索包含大小寫混合，則假設你需要區分大小寫
+opt.smartcase = true -- 如果搜索包含大小寫混合，則假設需要區分大小寫
 
 -- 光標行
 opt.cursorline = true -- 高亮當前光標所在行
 
 -- 外觀
-
--- 啟用 termguicolors 以使 nightfly 色彩主題生效
+opt.termguicolors = true -- 啟用 termguicolors 以使 nightfly 色彩主題生效
 -- （必須使用 iterm2 或其他支持真彩色的終端機）
-opt.termguicolors = true
-opt.background = "dark" -- 可以是亮色或暗色的色彩主題將被設為暗色
+opt.background = "dark" -- 將色彩主題設為暗色
 opt.signcolumn = "yes" -- 顯示標誌欄，以防文本位移
 
 -- 回退鍵
@@ -41,8 +39,11 @@ opt.splitright = true -- 垂直分割窗口向右分割
 opt.splitbelow = true -- 水平分割窗口向下分割
 
 -- 關閉交換檔案
-opt.swapfile = false
+opt.swapfile = false -- 禁用交換檔案
 
+-- 設定 Python 3 解釋器的路徑
 vim.g.python3_host_prog = "~/.pyenv/shims/python3"
+-- 禁用 Perl 支持
 vim.g.loaded_perl_provider = 0
+-- 禁用 Ruby 支持
 vim.g.loaded_ruby_provider = 0

--- a/lua/dast/plugins/bufferline.lua
+++ b/lua/dast/plugins/bufferline.lua
@@ -5,7 +5,6 @@ return {
   opts = {
     options = {
       mode = "tabs",
-      separator_style = "slant",
     },
   },
 }

--- a/lua/dast/plugins/colorscheme.lua
+++ b/lua/dast/plugins/colorscheme.lua
@@ -1,42 +1,46 @@
 ---@diagnostic disable: inject-field
 return {
-  {
-    "folke/tokyonight.nvim",
-    -- cond = false,
-    priority = 1000, -- make sure to load this before all the other start plugins
-    config = function()
-      local bg = "#011628"
-      local bg_dark = "#011423"
-      local bg_highlight = "#143652"
-      local bg_search = "#0A64AC"
-      local bg_visual = "#275378"
-      local fg = "#CBE0F0"
-      local fg_dark = "#B4D0E9"
-      local fg_gutter = "#627E97"
-      local border = "#547998"
+  "folke/tokyonight.nvim",
+  priority = 1000,
+  config = function()
+    local transparent = true -- set to true if you would like to enable transparency
 
-      require("tokyonight").setup({
-        style = "night",
-        on_colors = function(colors)
-          colors.bg = bg
-          colors.bg_dark = bg_dark
-          colors.bg_float = bg_dark
-          colors.bg_highlight = bg_highlight
-          colors.bg_popup = bg_dark
-          colors.bg_search = bg_search
-          colors.bg_sidebar = bg_dark
-          colors.bg_statusline = bg_dark
-          colors.bg_visual = bg_visual
-          colors.border = border
-          colors.fg = fg
-          colors.fg_dark = fg_dark
-          colors.fg_float = fg
-          colors.fg_gutter = fg_gutter
-          colors.fg_sidebar = fg_dark
-        end,
-      })
-      -- load the colorscheme here
-      vim.cmd([[colorscheme tokyonight]])
-    end,
-  },
+    local bg = "#011628"
+    local bg_dark = "#011423"
+    local bg_highlight = "#143652"
+    local bg_search = "#0A64AC"
+    local bg_visual = "#275378"
+    local fg = "#CBE0F0"
+    local fg_dark = "#B4D0E9"
+    local fg_gutter = "#627E97"
+    local border = "#547998"
+
+    require("tokyonight").setup({
+      style = "night",
+      transparent = transparent,
+      styles = {
+        sidebars = transparent and "transparent" or "dark",
+        floats = transparent and "transparent" or "dark",
+      },
+      on_colors = function(colors)
+        colors.bg = bg
+        colors.bg_dark = transparent and colors.none or bg_dark
+        colors.bg_float = transparent and colors.none or bg_dark
+        colors.bg_highlight = bg_highlight
+        colors.bg_popup = bg_dark
+        colors.bg_search = bg_search
+        colors.bg_sidebar = transparent and colors.none or bg_dark
+        colors.bg_statusline = transparent and colors.none or bg_dark
+        colors.bg_visual = bg_visual
+        colors.border = border
+        colors.fg = fg
+        colors.fg_dark = fg_dark
+        colors.fg_float = fg
+        colors.fg_gutter = fg_gutter
+        colors.fg_sidebar = fg_dark
+      end,
+    })
+
+    vim.cmd("colorscheme tokyonight")
+  end,
 }

--- a/lua/dast/plugins/lsp/formatting.lua
+++ b/lua/dast/plugins/lsp/formatting.lua
@@ -18,7 +18,7 @@ return {
       format_on_save = {
         lsp_fallback = true,
         async = false,
-        timeout_ms = 2000,
+        timeout_ms = 1000,
       },
     })
 

--- a/lua/dast/plugins/nvim-tree.lua
+++ b/lua/dast/plugins/nvim-tree.lua
@@ -12,7 +12,7 @@ return {
     nvimtree.setup({
       view = {
         width = 35,
-        relativenumber = false,
+        relativenumber = true,
       },
       -- change folder arrow icons
       renderer = {

--- a/lua/dast/plugins/nvim-treesitter-textobjects.lua
+++ b/lua/dast/plugins/nvim-treesitter-textobjects.lua
@@ -1,0 +1,110 @@
+return {
+  "nvim-treesitter/nvim-treesitter-textobjects",
+  lazy = true,
+  config = function()
+    require("nvim-treesitter.configs").setup({
+      textobjects = {
+        select = {
+          enable = true,
+
+          -- Automatically jump forward to textobj, similar to targets.vim
+          lookahead = true,
+
+          keymaps = {
+            -- You can use the capture groups defined in textobjects.scm
+            ["a="] = { query = "@assignment.outer", desc = "Select outer part of an assignment" },
+            ["i="] = { query = "@assignment.inner", desc = "Select inner part of an assignment" },
+            ["l="] = { query = "@assignment.lhs", desc = "Select left hand side of an assignment" },
+            ["r="] = { query = "@assignment.rhs", desc = "Select right hand side of an assignment" },
+
+            -- works for javascript/typescript files (custom capture I created in after/queries/ecma/textobjects.scm)
+            ["a:"] = { query = "@property.outer", desc = "Select outer part of an object property" },
+            ["i:"] = { query = "@property.inner", desc = "Select inner part of an object property" },
+            ["l:"] = { query = "@property.lhs", desc = "Select left part of an object property" },
+            ["r:"] = { query = "@property.rhs", desc = "Select right part of an object property" },
+
+            ["aa"] = { query = "@parameter.outer", desc = "Select outer part of a parameter/argument" },
+            ["ia"] = { query = "@parameter.inner", desc = "Select inner part of a parameter/argument" },
+
+            ["ai"] = { query = "@conditional.outer", desc = "Select outer part of a conditional" },
+            ["ii"] = { query = "@conditional.inner", desc = "Select inner part of a conditional" },
+
+            ["al"] = { query = "@loop.outer", desc = "Select outer part of a loop" },
+            ["il"] = { query = "@loop.inner", desc = "Select inner part of a loop" },
+
+            ["af"] = { query = "@call.outer", desc = "Select outer part of a function call" },
+            ["if"] = { query = "@call.inner", desc = "Select inner part of a function call" },
+
+            ["am"] = { query = "@function.outer", desc = "Select outer part of a method/function definition" },
+            ["im"] = { query = "@function.inner", desc = "Select inner part of a method/function definition" },
+
+            ["ac"] = { query = "@class.outer", desc = "Select outer part of a class" },
+            ["ic"] = { query = "@class.inner", desc = "Select inner part of a class" },
+          },
+        },
+        swap = {
+          enable = true,
+          swap_next = {
+            ["<leader>na"] = "@parameter.inner", -- swap parameters/argument with next
+            ["<leader>n:"] = "@property.outer", -- swap object property with next
+            ["<leader>nm"] = "@function.outer", -- swap function with next
+          },
+          swap_previous = {
+            ["<leader>pa"] = "@parameter.inner", -- swap parameters/argument with prev
+            ["<leader>p:"] = "@property.outer", -- swap object property with prev
+            ["<leader>pm"] = "@function.outer", -- swap function with previous
+          },
+        },
+        move = {
+          enable = true,
+          set_jumps = true, -- whether to set jumps in the jumplist
+          goto_next_start = {
+            ["]f"] = { query = "@call.outer", desc = "Next function call start" },
+            ["]m"] = { query = "@function.outer", desc = "Next method/function def start" },
+            ["]c"] = { query = "@class.outer", desc = "Next class start" },
+            ["]i"] = { query = "@conditional.outer", desc = "Next conditional start" },
+            ["]l"] = { query = "@loop.outer", desc = "Next loop start" },
+
+            -- You can pass a query group to use query from `queries/<lang>/<query_group>.scm file in your runtime path.
+            -- Below example nvim-treesitter's `locals.scm` and `folds.scm`. They also provide highlights.scm and indent.scm.
+            ["]s"] = { query = "@scope", query_group = "locals", desc = "Next scope" },
+            ["]z"] = { query = "@fold", query_group = "folds", desc = "Next fold" },
+          },
+          goto_next_end = {
+            ["]F"] = { query = "@call.outer", desc = "Next function call end" },
+            ["]M"] = { query = "@function.outer", desc = "Next method/function def end" },
+            ["]C"] = { query = "@class.outer", desc = "Next class end" },
+            ["]I"] = { query = "@conditional.outer", desc = "Next conditional end" },
+            ["]L"] = { query = "@loop.outer", desc = "Next loop end" },
+          },
+          goto_previous_start = {
+            ["[f"] = { query = "@call.outer", desc = "Prev function call start" },
+            ["[m"] = { query = "@function.outer", desc = "Prev method/function def start" },
+            ["[c"] = { query = "@class.outer", desc = "Prev class start" },
+            ["[i"] = { query = "@conditional.outer", desc = "Prev conditional start" },
+            ["[l"] = { query = "@loop.outer", desc = "Prev loop start" },
+          },
+          goto_previous_end = {
+            ["[F"] = { query = "@call.outer", desc = "Prev function call end" },
+            ["[M"] = { query = "@function.outer", desc = "Prev method/function def end" },
+            ["[C"] = { query = "@class.outer", desc = "Prev class end" },
+            ["[I"] = { query = "@conditional.outer", desc = "Prev conditional end" },
+            ["[L"] = { query = "@loop.outer", desc = "Prev loop end" },
+          },
+        },
+      },
+    })
+
+    local ts_repeat_move = require("nvim-treesitter.textobjects.repeatable_move")
+
+    -- vim way: ; goes to the direction you were moving.
+    vim.keymap.set({ "n", "x", "o" }, ";", ts_repeat_move.repeat_last_move)
+    vim.keymap.set({ "n", "x", "o" }, ",", ts_repeat_move.repeat_last_move_opposite)
+
+    -- Optionally, make builtin f, F, t, T also repeatable with ; and ,
+    vim.keymap.set({ "n", "x", "o" }, "f", ts_repeat_move.builtin_f)
+    vim.keymap.set({ "n", "x", "o" }, "F", ts_repeat_move.builtin_F)
+    vim.keymap.set({ "n", "x", "o" }, "t", ts_repeat_move.builtin_t)
+    vim.keymap.set({ "n", "x", "o" }, "T", ts_repeat_move.builtin_T)
+  end,
+}

--- a/lua/dast/plugins/substitute.lua
+++ b/lua/dast/plugins/substitute.lua
@@ -1,0 +1,17 @@
+return {
+  "gbprod/substitute.nvim",
+  event = { "BufReadPre", "BufNewFile" },
+  config = function()
+    local substitute = require("substitute")
+
+    substitute.setup()
+
+    -- set keymaps
+    local keymap = vim.keymap -- for conciseness
+
+    keymap.set("n", "s", substitute.operator, { desc = "Substitute with motion" })
+    keymap.set("n", "ss", substitute.line, { desc = "Substitute line" })
+    keymap.set("n", "S", substitute.eol, { desc = "Substitute to end of line" })
+    keymap.set("x", "s", substitute.visual, { desc = "Substitute in visual mode" })
+  end,
+}

--- a/lua/dast/plugins/telescope.lua
+++ b/lua/dast/plugins/telescope.lua
@@ -1,7 +1,5 @@
 return {
   "nvim-telescope/telescope.nvim",
-  -- cond = false,
-  event = "VeryLazy",
   branch = "0.1.x",
   dependencies = {
     "nvim-lua/plenary.nvim",
@@ -11,8 +9,18 @@ return {
   },
   config = function()
     local telescope = require("telescope")
-
     local actions = require("telescope.actions")
+    local transform_mod = require("telescope.actions.mt").transform_mod
+
+    local trouble = require("trouble")
+    local trouble_telescope = require("trouble.sources.telescope")
+
+    -- or create your custom action
+    local custom_actions = transform_mod({
+      open_trouble_qflist = function(prompt_bufnr)
+        trouble.toggle("quickfix")
+      end,
+    })
 
     telescope.setup({
       defaults = {
@@ -21,7 +29,8 @@ return {
           i = {
             ["<C-k>"] = actions.move_selection_previous, -- move to prev result
             ["<C-j>"] = actions.move_selection_next, -- move to next result
-            ["<C-q>"] = actions.send_selected_to_qflist + actions.open_qflist,
+            ["<C-q>"] = actions.send_selected_to_qflist + custom_actions.open_trouble_qflist,
+            ["<C-t>"] = trouble_telescope.open,
           },
         },
       },

--- a/lua/dast/plugins/trouble.lua
+++ b/lua/dast/plugins/trouble.lua
@@ -3,12 +3,15 @@ return {
   -- cond = false,
   event = "VeryLazy",
   dependencies = { "nvim-tree/nvim-web-devicons", "folke/todo-comments.nvim" },
+  opts = {
+    focus = true,
+  },
+  cmd = "Trouble",
   keys = {
-    { "<leader>xx", "<cmd>TroubleToggle<CR>", desc = "Open/close trouble list" },
-    { "<leader>xw", "<cmd>TroubleToggle workspace_diagnostics<CR>", desc = "Open trouble workspace diagnostics" },
-    { "<leader>xd", "<cmd>TroubleToggle document_diagnostics<CR>", desc = "Open trouble document diagnostics" },
-    { "<leader>xq", "<cmd>TroubleToggle quickfix<CR>", desc = "Open trouble quickfix list" },
-    { "<leader>xl", "<cmd>TroubleToggle loclist<CR>", desc = "Open trouble location list" },
-    { "<leader>xt", "<cmd>TodoTrouble<CR>", desc = "Open todos in trouble" },
+    { "<leader>xw", "<cmd>Trouble diagnostics toggle<CR>", desc = "Open trouble workspace diagnostics" },
+    { "<leader>xd", "<cmd>Trouble diagnostics toggle filter.buf=0<CR>", desc = "Open trouble document diagnostics" },
+    { "<leader>xq", "<cmd>Trouble quickfix toggle<CR>", desc = "Open trouble quickfix list" },
+    { "<leader>xl", "<cmd>Trouble loclist toggle<CR>", desc = "Open trouble location list" },
+    { "<leader>xt", "<cmd>Trouble todo toggle<CR>", desc = "Open todos in trouble" },
   },
 }

--- a/lua/dast/plugins/which-key.lua
+++ b/lua/dast/plugins/which-key.lua
@@ -5,7 +5,7 @@ return {
     event = "VeryLazy",
     init = function()
       vim.o.timeout = true
-      vim.o.timeoutlen = 300
+      vim.o.timeoutlen = 500
       --BUG: conflicting keymaps "gc"
       -- unmap gc keymap
       vim.api.nvim_set_keymap("n", "gc", "", { noremap = true, silent = true })


### PR DESCRIPTION
- Update the keymaps for exiting insert mode, clearing search highlights, and incrementing/decrementing numbers in `lua/dast/core/keymaps.lua`
- Modify Vim options related to line numbers, search settings, appearance, termguicolors, visualization, and backspace in `lua/dast/core/options.lua`
- Remove the `separator_style` option in `lua/dast/plugins/bufferline.lua`
- Adjust the `priority` and `transparent` settings for a colorscheme in `lua/dast/plugins/colorscheme.lua`
- Reduce the `timeout_ms` for `format_on_save` in a LSP-related file `lua/dast/plugins/lsp/formatting.lua`
- Update the `relativenumber` setting in `nvim-tree.lua` in `lua/dast/plugins/nvim-tree.lua`
- Add text objects for various programming constructs in `nvim-treesitter-textobjects.lua`
- Add keymaps for substitution operations in `substitute.lua`
- Update keymaps and commands for trouble-related actions in `trouble.lua`
- Adjust the `timeoutlen` for key timeout in `which-key.lua`

Signed-off-by: OfficePC-WSL <jackie@dast.tw>
