### PR TITLE
fix: refactor Vim configuration options

### DIFF
--- a/lua/dast/plugins/auto-session.lua
+++ b/lua/dast/plugins/auto-session.lua
@@ -9,10 +9,11 @@ return {
       auto_session_suppress_dirs = { "~/", "~/Dev/", "~/Downloads", "~/Documents", "~/Desktop/" },
     })
 
+    vim.o.sessionoptions = "blank,buffers,curdir,folds,help,tabpages,winsize,winpos,terminal,localoptions"
+
     local keymap = vim.keymap
 
     keymap.set("n", "<leader>wr", "<cmd>SessionRestore<CR>", { desc = "Restore session for cwd" }) -- 恢復至上一個儲存的工作區
     keymap.set("n", "<leader>ws", "<cmd>SessionSave<CR>", { desc = "Save session for auto session root dir" }) -- 將目前作業路徑儲存至工作區
-    vim.o.sessionoptions = "blank,buffers,curdir,folds,help,tabpages,winsize,winpos,terminal,localoptions"
   end,
 }


### PR DESCRIPTION
- Update `vim.o.sessionoptions` setting
- Remove duplicate assignment of `vim.o.sessionoptions`

Signed-off-by: OfficePC-WSL <jackie@dast.tw>
