### PR TITLE
chore: refactor code formatting and linting configurations

### DIFF
--- a/lua/dast/plugins/lsp/formatting.lua
+++ b/lua/dast/plugins/lsp/formatting.lua
@@ -8,7 +8,7 @@ return {
     conform.setup({
       formatters_by_ft = {
         lua = { "stylua" },
-        python = { "isort", "black" },
+        python = { "black" },
         sh = { "shfmt" },
         bash = { "shfmt" },
         markdown = { "prettier" },

--- a/lua/dast/plugins/lsp/linting.lua
+++ b/lua/dast/plugins/lsp/linting.lua
@@ -6,7 +6,7 @@ return {
     local lint = require("lint")
 
     lint.linters_by_ft = {
-      python = { "pylint", "flake8", "mypy" },
+      python = { "pylint", "mypy" },
       bash = { "shellcheck" },
       sh = { "shellcheck" },
     }

--- a/lua/dast/plugins/lsp/mason.lua
+++ b/lua/dast/plugins/lsp/mason.lua
@@ -41,10 +41,8 @@ return {
         "shellcheck", --  ShellCheck, a static analysis tool for shell scripts.
         "pylint", -- Pylint is a static code analyser for Python 2 or 3.
         "stylua", -- An opinionated Lua code formatter.
-        "isort", -- isort is a Python utility / library to sort imports alphabetically.
         "shfmt", -- A shell formatter (sh/bash/mksh).
         "debugpy",
-        "flake8",
         "mypy",
         "bash-debug-adapter",
       },


### PR DESCRIPTION
- Remove `isort` from the python formatters in `formatting.lua`
- Remove `flake8` from the python linters in `linting.lua`
- Update `mason.lua` by removing `isort` and `flake8` configuration

Signed-off-by: Macbook <jackie@dast.tw>
