### PR TITLE
build: refactor file path restrictions for enhanced flexibility

### DIFF
--- a/lua/dast/plugins/auto-session.lua
+++ b/lua/dast/plugins/auto-session.lua
@@ -12,6 +12,7 @@ return {
   opts = {
     auto_restore = false,
     bypass_save_filetypes = { "alpha", "dashboard" },
-    suppress_dirs = { "~/", "~/Downloads", "~/Documents", "~/Desktop/" },
+    allowed_dirs = { "~/Documents/github" },
+    suppress_dirs = { "~/", "~/Downloads", "~/Desktop/" },
   },
 }


### PR DESCRIPTION
- Add `~/Documents/github` to `allowed_dirs`
- Update `suppress_dirs` to exclude only specific directories

Signed-off-by: HomePC-WSL <jackie@dast.tw>
