### PR TITLE
chore: simplify configuration settings

### DIFF
--- a/lua/dast/plugins/auto-session.lua
+++ b/lua/dast/plugins/auto-session.lua
@@ -12,7 +12,6 @@ return {
   opts = {
     auto_restore = false,
     bypass_save_filetypes = { "alpha", "dashboard" },
-    allowed_dirs = { "~/Documents/github" },
     suppress_dirs = { "~/", "~/Downloads", "~/Desktop/" },
   },
 }


### PR DESCRIPTION
- Remove the `allowed_dirs` configuration option

Signed-off-by: HomePC-WSL <jackie@dast.tw>
