### PR TITLE
chore: refactor file type handling and directory suppression

### DIFF
--- a/lua/dast/plugins/auto-session.lua
+++ b/lua/dast/plugins/auto-session.lua
@@ -12,6 +12,6 @@ return {
   opts = {
     auto_restore = false,
     bypass_save_filetypes = { "alpha", "dashboard" },
-    suppress_dirs = { "~/", "~/Downloads", "~/Desktop/" },
+    suppress_dirs = { "~/", "~/Downloads/", "~/Desktop/" },
   },
 }


### PR DESCRIPTION
- Modify the `bypass_save_filetypes` to include `'dashboard'`
- Update the `suppress_dirs` to also include `'Downloads'`

Signed-off-by: HomePC-WSL <jackie@dast.tw>
