### PR TITLE
refactor: update Python DAP setup paths and version handling

### DIFF
--- a/lua/dast/plugins/debug/dap-python.lua
+++ b/lua/dast/plugins/debug/dap-python.lua
@@ -10,7 +10,7 @@ return {
       "rcarriga/nvim-dap-ui",
     },
     config = function()
-      require("dap-python").setup("~/.pyenv/shims/python3")
+      require("dap-python").setup("python3")
 
       local dap = require("dap")
 


### PR DESCRIPTION
- Update the Python DAP setup to use a different path
- Change the Python DAP setup to use a simpler Python version identifier

Signed-off-by: Macbook <jackie@dast.tw>
